### PR TITLE
Update node-pty dep version (for node 12 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-changed",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Spawns babel with --only files modified since last run",
   "main": "lib/index.js",
   "bin": {
@@ -39,6 +39,6 @@
     "hash-sum": "^1.0.2",
     "lodash.uniq": "^4.5.0",
     "path-exists": "^3.0.0",
-    "node-pty": "^0.9.0-beta"
+    "node-pty": "^0.9.0-beta18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "hash-sum": "^1.0.2",
     "lodash.uniq": "^4.5.0",
     "path-exists": "^3.0.0",
-    "node-pty": "^0.8.1"
+    "node-pty": "^0.9.0-beta"
   }
 }


### PR DESCRIPTION
`node-pty` fails to build on node > `11.15.x`. Fixed in upcoming `0.9` release.
For more details, see:
https://github.com/microsoft/node-pty/issues/319#issuecomment-497979148